### PR TITLE
Fix bug when no magnitude available using Hypo2000Arc

### DIFF
--- a/src/NLLocLib.c
+++ b/src/NLLocLib.c
@@ -11943,6 +11943,7 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
     ArrivalDesc *parr, *psarr;
     double rms, resid, amplitude;
     double dtemp;
+    char chrtmp[MAXSTRING];
 
     char first_mot;
 
@@ -11995,8 +11996,14 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
         amp_mag_wt = (double) phypo->num_amp_mag;
     } else if (haveSumHdr) {
         // 37 3 F3.2 Amplitude magnitude.
-        sscanf(HypoInverseArchiveSumHdr + 36, "%3lf", &amp_mag);
-        amp_mag /= 100.0;
+        // JMS 20210304 - bug fix: added checks for no mag
+        strncpy(chrtmp, HypoInverseArchiveSumHdr + 36, 3);
+        chrtmp[3] = '\0';
+        if (sscanf(chrtmp, "%3lf", &amp_mag) != 0) {
+          amp_mag /= 100.0;
+        } else {
+          amp_mag = 0.0;
+        }
     } else {
         amp_mag = 0.0;
     }
@@ -12006,8 +12013,14 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
         dur_mag_wt = (double) phypo->num_dur_mag;
     } else if (haveSumHdr) {
         // 71 3 F3.2 Coda duration magnitude.
-        sscanf(HypoInverseArchiveSumHdr + 70, "%3lf", &dur_mag);
-        dur_mag /= 100.0;
+        // JMS 20210304 - bug fix: added checks for no mag
+        strncpy(chrtmp, HypoInverseArchiveSumHdr + 70, 3);
+        chrtmp[3] = '\0';
+        if (sscanf(chrtmp, "%3lf", &dur_mag) != 0) {
+          dur_mag /= 100.0;
+        } else {
+          dur_mag = 0.0;
+        }
     } else {
         dur_mag = 0.0;
     }
@@ -12056,10 +12069,16 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
             100.0 * phypo->depth);
     // 37 3 F3.2 Amplitude magnitude. *
     // AJL 20080304 - bug fix: added checks for MAGNITUDE_NULL
-    if (writeY2000)
-        fprintf(fpio, "%3.0lf", fabs(amp_mag - MAGNITUDE_NULL) > 0.01 ? 100.0 * amp_mag : 0.0);
-    else
-        fprintf(fpio, "%2.0lf", fabs(amp_mag - MAGNITUDE_NULL) > 0.01 ? 10.0 * amp_mag : 0.0);
+    // JMS 20210304 - improvement: seems unecessary now, check performed earlier at mag reading
+    // JMS 20210304 - bug fix: if no magnitude, print spaces
+    if (amp_mag == 0.0)
+        fprintf(fpio, "%s", writeY2000 ? "   " : "  " );
+    else {
+          if (writeY2000)
+              fprintf(fpio, "%3.0lf", 100.0 * amp_mag);
+          else
+              fprintf(fpio, "%2.0lf", 10.0 * amp_mag);
+        }
     // 40 3 I3 Number of P & S times with final weights greater than 0.1.
     // 43 3 I3 Maximum azimuthal gap, degrees.
     // 46 3 F3.0 Distance to nearest station (km).
@@ -12101,6 +12120,15 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
     fprintf(fpio, "000000000000000000");
 
     // 71 3 F3.2 Coda duration magnitude. *
+    // JMS 20210304 - bug fix: if no magnitude, print spaces
+    if (dur_mag == 0.0)
+        fprintf(fpio, "%s", writeY2000 ? "   " : "  " );
+    else {
+          if (writeY2000)
+              fprintf(fpio, "%3.0lf", 100.0 * dur_mag);
+          else
+              fprintf(fpio, "%2.0lf", 10.0 * dur_mag);
+        }
     // 74 3 A3 Event location remark (region), derived from location.
     // 77 4 F4.2 Size of smallest principal error (km).
     // 81 1 A1 Auxiliary remark from analyst (i.e. Q for quarry).
@@ -12109,14 +12137,12 @@ int WriteHypoInverseArchive(FILE *fpio, HypoDesc *phypo, ArrivalDesc *parrivals,
     // 86 4 F4.2 Horizontal error (km).
     // 90 4 F4.2 Vertical error (km).
     if (writeY2000) {
-        fprintf(fpio, "%3.0lf", 100.0 * dur_mag);
         // TODO this is largest princiapl error !!
         dtemp = 100.0 * phypo->ellipsoid.len3;
         fprintf(fpio, "%3.3s%4.0lf", loc_remark, dtemp < 9999.0 ? dtemp : 9999.0);
         fprintf(fpio, "%1.1s%1.1s%3.3d%4.0lf%4.0lf",
                 aux_remark, aux_remark_prog, num_S_wt, err_horiz, err_vert);
     } else {
-        fprintf(fpio, "%2.0lf", 10.0 * dur_mag);
         dtemp = 100.0 * phypo->ellipsoid.len3;
         fprintf(fpio, "%3.3s%4.0lf", loc_remark, dtemp < 9999.0 ? dtemp : 9999.0);
         fprintf(fpio, "%1.1s%1.1s%2.2d%4.0lf%4.0lf",
@@ -14290,6 +14316,3 @@ int GenEventScatterOcttree(OcttreeParams* pParams, double oct_node_value_max, fl
 
 /** end of Octree search routines */
 /*------------------------------------------------------------/ */
-
-
-


### PR DESCRIPTION
When no magnitude was computed by NLLoc and no magnitude available from an Hypo2000Arc input message, the magnitude values where read from the first numbers following the blank spaces in the input message, resulting in a magnitude in the output without any meaning.

This fix now checks for blank spaces in the input Hypo2000Arc message if no magnitude has been computed and writes blank spaces in the Hypo2000Arc message if no magnitude is available.