### PR TITLE
misc: some Makefile fixes and add little lat/lon to x/y converter

### DIFF
--- a/misc/GridLift.c
+++ b/misc/GridLift.c
@@ -160,10 +160,10 @@ grid_out.iSwapBytes = 0;
 		printf("ix = %d/%d\r", ix, grid_in.numx);
 		for (iy = 0; iy < grid_in.numy; iy++) {
 			for (iz = 0; iz < grid_in.numz; iz++) {
-				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in);
+				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in, 0);
 				if (val >= cutoff && iz < grid_in.numz - 1
 					&& (val_below =
-						ReadGrid3dValue(fp_grid_in, ix, iy, iz + 1, &grid_in))
+						ReadGrid3dValue(fp_grid_in, ix, iy, iz + 1, &grid_in, 0))
 						< cutoff) {
 					grid_out.array[ix][iy][iz] = val_below;
 					nlift++;

--- a/misc/GridProc.c
+++ b/misc/GridProc.c
@@ -37,7 +37,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 // defines

--- a/misc/GridReplaceValue.c
+++ b/misc/GridReplaceValue.c
@@ -157,7 +157,7 @@ grid_out.iSwapBytes = 0;
 		printf("ix = %d/%d\r", ix, grid_in.numx);
 		for (iy = 0; iy < grid_in.numy; iy++) {
 			for (iz = 0; iz < grid_in.numz; iz++) {
-				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in);
+				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in), 0;
 				if (val >= old_value_minus_tolerance && val <= old_value_plus_tolerance) {
 					grid_out.array[ix][iy][iz] = new_value;
 					nreplaced++;

--- a/misc/GridRotate.c
+++ b/misc/GridRotate.c
@@ -174,7 +174,7 @@ int Rotate90CW(int argc, char *argv[])
 		printf("ix = %d/%d\r", ix, grid_in.numx);
 		for (iy = 0; iy < grid_in.numy; iy++) {
 			for (iz = 0; iz < grid_in.numz; iz++) {
-				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in);
+				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in, 0);
 				grid_out.array[iy][grid_out.numy - ix - 1][iz] = val;
 			}
 		}

--- a/misc/GridXY2XYZ.c
+++ b/misc/GridXY2XYZ.c
@@ -46,7 +46,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 // defines

--- a/misc/GridXY2XYZ.c
+++ b/misc/GridXY2XYZ.c
@@ -162,7 +162,7 @@ int AddZ(int argc, char *argv[])
 		printf("ix = %d/%d\r", ix, grid_in.numx);
 		for (iy = 0; iy < grid_in.numy; iy++) {
 			for (iz = 0; iz < grid_in.numz; iz++) {
-				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in);
+				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in, 0);
 				if (val < val_min)
 					val = val_min;
 				if (val > val_max)

--- a/misc/HypDiff.c
+++ b/misc/HypDiff.c
@@ -37,7 +37,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -47,7 +47,7 @@ export CCFLAGS = $(CCFLAGS_BASIC) -g
 
 
 
-all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ isc_isf2hyp_ hyp2bull_ GridProc_ compare_geog_trans_
+all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ isc_isf2hyp_ hyp2bull_ GridProc_ compare_geog_trans_ lonlat_2_xy_
 
 #GRID_LIB_OBJS=${SRC_PATH}/GridLib.o ${SRC_PATH}/util.o ${SRC_PATH}/geo.o ${SRC_PATH}/octtree/octtree.o ${SRC_PATH}/alomax_matrix/alomax_matrix.o ${SRC_PATH}/alomax_matrix/alomax_matrix_svd.o ${SRC_PATH}/matrix_statistics/matrix_statistics.o ${SRC_PATH}/vector/vector.o ${SRC_PATH}/ran1/ran1.o ${SRC_PATH}/map_project.o
 GRID_LIB_OBJS=../src/CMakeFiles/GRID_LIB_OBJS.dir/GridLib.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/util.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/geo.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/octtree/octtree.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/eigv.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix_svd.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/matrix_statistics/matrix_statistics.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/vector/vector.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/ran1/ran1.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/map_project.c.o
@@ -315,6 +315,19 @@ $(BINDIR)/hyp_gt_2_corr : $(OBJS23)
 hyp_gt_2_corr.o : hyp_gt_2_corr.c ${SRC_PATH}/include/GridLib.h
 	${CC} $(CCFLAGS) -c hyp_gt_2_corr.c
 # --------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------
+# lonlat_2_xy
+#
+OBJS24 = lonlat_2_xy.o $(GRID_LIB_OBJS)
+lonlat_2_xy_ : $(BINDIR)/lonlat_2_xy
+$(BINDIR)/lonlat_2_xy : $(OBJS24)
+	${CC} $(OBJS24) $(CCFLAGS) -o $(BINDIR)/lonlat_2_xy -lm
+lonlat_2_xy.o : lonlat_2_xy.c ${SRC_PATH}/include/GridLib.h
+	${CC} $(CCFLAGS) -c lonlat_2_xy.c
+# --------------------------------------------------------------------------
+
 
 
 # --------------------------------------------------------------------------

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -47,7 +47,7 @@ export CCFLAGS = $(CCFLAGS_BASIC) -g
 
 
 
-all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ isc_isf2hyp_ hyp2bull_ GridProc_
+all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ isc_isf2hyp_ hyp2bull_ GridProc_ compare_geog_trans_
 
 #GRID_LIB_OBJS=${SRC_PATH}/GridLib.o ${SRC_PATH}/util.o ${SRC_PATH}/geo.o ${SRC_PATH}/octtree/octtree.o ${SRC_PATH}/alomax_matrix/alomax_matrix.o ${SRC_PATH}/alomax_matrix/alomax_matrix_svd.o ${SRC_PATH}/matrix_statistics/matrix_statistics.o ${SRC_PATH}/vector/vector.o ${SRC_PATH}/ran1/ran1.o ${SRC_PATH}/map_project.o
 GRID_LIB_OBJS=../src/CMakeFiles/GRID_LIB_OBJS.dir/GridLib.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/util.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/geo.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/octtree/octtree.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/eigv.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix_svd.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/matrix_statistics/matrix_statistics.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/vector/vector.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/ran1/ran1.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/map_project.c.o

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -47,7 +47,7 @@ export CCFLAGS = $(CCFLAGS_BASIC) -g
 
 
 
-all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ hypoe2hyp_ fpfit2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ GridXY2XYZ_ isc_isf2hyp_ hyp2bull_ GridProc_
+all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ GridXY2XYZ_ isc_isf2hyp_ hyp2bull_ GridProc_
 
 #GRID_LIB_OBJS=${SRC_PATH}/GridLib.o ${SRC_PATH}/util.o ${SRC_PATH}/geo.o ${SRC_PATH}/octtree/octtree.o ${SRC_PATH}/alomax_matrix/alomax_matrix.o ${SRC_PATH}/alomax_matrix/alomax_matrix_svd.o ${SRC_PATH}/matrix_statistics/matrix_statistics.o ${SRC_PATH}/vector/vector.o ${SRC_PATH}/ran1/ran1.o ${SRC_PATH}/map_project.o
 GRID_LIB_OBJS=../src/CMakeFiles/GRID_LIB_OBJS.dir/GridLib.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/util.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/geo.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/octtree/octtree.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/eigv.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix_svd.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/matrix_statistics/matrix_statistics.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/vector/vector.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/ran1/ran1.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/map_project.c.o
@@ -100,31 +100,6 @@ $(BINDIR)/hypoinv2hyp : $(OBJS6)
 hypoinv2hyp.o : hypoinv2hyp.c ${SRC_PATH}/include/GridLib.h
 	${CC} $(CCFLAGS) -c hypoinv2hyp.c
 # --------------------------------------------------------------------------
-
-# --------------------------------------------------------------------------
-# hypoe2hyp
-#
-OBJS7=hypoe2hyp.o $(GRID_LIB_OBJS)
-hypoe2hyp_ : ${BINDIR}/hypoe2hyp
-${BINDIR}/hypoe2hyp : ${OBJS7}
-	${CC} ${OBJS7} ${CCFLAGS} -o ${BINDIR}/hypoe2hyp -lm
-hypoe2hyp.o : hypoe2hyp.c ${SRC_PATH}/include/GridLib.h
-	${CC} ${CCFLAGS} -c hypoe2hyp.c
-# --------------------------------------------------------------------------
-
-
-
-# --------------------------------------------------------------------------
-# fpfit2hyp
-#
-OBJS8=fpfit2hyp.o $(GRID_LIB_OBJS)
-fpfit2hyp_ : ${BINDIR}/fpfit2hyp
-${BINDIR}/fpfit2hyp : ${OBJS8}
-	${CC} ${OBJS8} ${CCFLAGS} -o ${BINDIR}/fpfit2hyp -lm
-fpfit2hyp.o : fpfit2hyp.c ${SRC_PATH}/include/GridLib.h
-	${CC} ${CCFLAGS} -c fpfit2hyp.c
-# --------------------------------------------------------------------------
-
 
 
 # --------------------------------------------------------------------------

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -75,7 +75,7 @@ OBJS5 = alberto2hyp.o $(GRID_LIB_OBJS)
 alberto2hyp_ : $(BINDIR)/alberto2hyp
 $(BINDIR)/alberto2hyp : $(OBJS5)
 	${CC} $(OBJS5) $(CCFLAGS) -o $(BINDIR)/alberto2hyp -lm
-alberto2hyp.o : alberto2hyp.c ${SRC_PATH}/include/GridLib.h
+alberto2hyp.o : alberto2hyp.c ${SRC_PATH}/include/GridLib.h ingv_list2hyp.o
 	${CC} $(CCFLAGS) -c alberto2hyp.c
 # --------------------------------------------------------------------------
 

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -47,7 +47,7 @@ export CCFLAGS = $(CCFLAGS_BASIC) -g
 
 
 
-all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ GridXY2XYZ_ isc_isf2hyp_ hyp2bull_ GridProc_
+all : HypDiff_ alberto2hyp_ ingv_list2hyp_ hypoinv2hyp_ diffTime_ MergeFpfit_ MergeFmamp_ isc_isf2hyp_ hyp2bull_ GridProc_
 
 #GRID_LIB_OBJS=${SRC_PATH}/GridLib.o ${SRC_PATH}/util.o ${SRC_PATH}/geo.o ${SRC_PATH}/octtree/octtree.o ${SRC_PATH}/alomax_matrix/alomax_matrix.o ${SRC_PATH}/alomax_matrix/alomax_matrix_svd.o ${SRC_PATH}/matrix_statistics/matrix_statistics.o ${SRC_PATH}/vector/vector.o ${SRC_PATH}/ran1/ran1.o ${SRC_PATH}/map_project.o
 GRID_LIB_OBJS=../src/CMakeFiles/GRID_LIB_OBJS.dir/GridLib.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/util.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/geo.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/octtree/octtree.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/eigv.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/alomax_matrix/alomax_matrix_svd.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/matrix_statistics/matrix_statistics.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/vector/vector.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/ran1/ran1.c.o ../src/CMakeFiles/GRID_LIB_OBJS.dir/map_project.c.o
@@ -143,12 +143,12 @@ diffTime.o : diffTime.c ${SRC_PATH}/include/GridLib.h
 # --------------------------------------------------------------------------
 # GridXY2XYZ
 #
-OBJS11 = GridXY2XYZ.o $(GRID_LIB_OBJS)
-GridXY2XYZ_ : $(BINDIR)/GridXY2XYZ
-$(BINDIR)/GridXY2XYZ : $(OBJS11)
-	${CC} $(OBJS11) $(CCFLAGS) -o $(BINDIR)/GridXY2XYZ -lm
-GridXY2XYZ.o : GridXY2XYZ.c ${SRC_PATH}/include/GridLib.h
-	${CC} $(CCFLAGS) -c GridXY2XYZ.c
+#OBJS11 = GridXY2XYZ.o $(GRID_LIB_OBJS)
+#GridXY2XYZ_ : $(BINDIR)/GridXY2XYZ
+#$(BINDIR)/GridXY2XYZ : $(OBJS11)
+#	${CC} $(OBJS11) $(CCFLAGS) -o $(BINDIR)/GridXY2XYZ -lm
+#GridXY2XYZ.o : GridXY2XYZ.c ${SRC_PATH}/include/GridLib.h
+#	${CC} $(CCFLAGS) -c GridXY2XYZ.c
 # --------------------------------------------------------------------------
 
 

--- a/misc/MergeFpfit.c
+++ b/misc/MergeFpfit.c
@@ -37,7 +37,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/alberto2hyp.c
+++ b/misc/alberto2hyp.c
@@ -43,7 +43,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/compare_geog_trans.c
+++ b/misc/compare_geog_trans.c
@@ -52,7 +52,7 @@ e-mail: anthony@alomax.net  web: http://www.alomax.net
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "gridlib.h"
+#include "../src/include/GridLib.h"
 
 
 /** program to test geo.h function calls

--- a/misc/diffTime.c
+++ b/misc/diffTime.c
@@ -45,7 +45,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/grid2asc.c
+++ b/misc/grid2asc.c
@@ -145,7 +145,7 @@ int DumpToASCII(int argc, char *argv[])
 	for (ix = 0; ix < grid_in.numx; ix++) {
 		for (iy = 0; iy < grid_in.numy; iy++) {
 			for (iz = 0; iz < grid_in.numz; iz++) {
-				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in);
+				val = ReadGrid3dValue(fp_grid_in, ix, iy, iz, &grid_in, 0);
 				printf("%f ", val);
 			}
 			printf("\n");

--- a/misc/hyp2bull.c
+++ b/misc/hyp2bull.c
@@ -41,7 +41,7 @@ tel: +33(0)493752502  e-mail: anthony@alomax.net  web: http://www.alomax.net
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/hypoinv2hyp.c
+++ b/misc/hypoinv2hyp.c
@@ -43,7 +43,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/ingv_list2hyp.c
+++ b/misc/ingv_list2hyp.c
@@ -36,7 +36,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/isc_isf2hyp.c
+++ b/misc/isc_isf2hyp.c
@@ -36,7 +36,7 @@
 
 
 
-#include "../src/GridLib.h"
+#include "../src/include/GridLib.h"
 
 
 /* defines */

--- a/misc/lonlat_2_xy.c
+++ b/misc/lonlat_2_xy.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2017 Anthony Lomax <anthony@alomax.net, http://www.alomax.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser Public License for more details.
+
+ * You should have received a copy of the GNU Lesser Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+
+/*   lonlat_2_xy.c
+
+   Program to convert longitude/latitude values to x/y in given transformation
+
+
+ */
+
+/*-----------------------------------------------------------------------
+Anthony Lomax
+Anthony Lomax Scientific Software
+e-mail: anthony@alomax.net  web: http://www.alomax.net
+-------------------------------------------------------------------------*/
+
+
+/*
+        history:	(see also http://alomax.net/nlloc -> Updates)
+
+        ver 01    30JUN2022  TM   Original version
+
+        see GridLib.c
+
+
+.........1.........2.........3.........4.........5.........6.........7.........8
+
+ */
+
+
+
+
+
+#define PNAME  "lonlat_2_xy"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "../src/include/GridLib.h"
+
+
+/** program to test geo.h function calls
+ *
+ */
+
+
+#define NARGS_MIN 0
+#define ARG_DESC ""
+
+int main(int argc, char *argv[]) {
+
+    // check command line for correct usage
+    if (argc < NARGS_MIN) {
+        fprintf(stderr, "Usage: %s %s\n", PNAME, ARG_DESC);
+        return (-1);
+    }
+
+    SetConstants();
+
+// emulate https://epsg.io/25832
+// false easting should be 500000 for correct results, but hard coded to 0 right now
+// scale factor should be 0.9996 for correct results, but is hard coded to 1.0 right now
+#define EARTH_ELLIPSOID "GRS-80"
+#define MAP_ORIG_LAT 0.0
+#define MAP_ORIG_LON 9.0
+#define ROTATION_ANGLE 0.0
+
+    int num_projections = 1;
+    char trans[num_projections][999];
+
+    int n = 0;
+    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f ", EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE);
+
+    for (int n_proj = 0; n_proj < num_projections; n_proj++) {
+        get_transform(n_proj, trans[n_proj]);
+    }
+
+    float TEST_ORIG_LAT;
+    float TEST_ORIG_LON;
+
+    printf("Enter longitude and latitude, separated by space: ");
+    scanf("%f %f", &TEST_ORIG_LON, &TEST_ORIG_LAT);
+    printf("Longitude: %f\n", TEST_ORIG_LON);
+    printf("Latitude: %f\n", TEST_ORIG_LAT);
+
+    for (int n_proj = 0; n_proj < num_projections; n_proj++) {
+        if (strcmp(map_trans_type[n_proj], "GLOBAL") == 0) {
+            GeometryMode = MODE_GLOBAL;
+        } else {
+            GeometryMode = MODE_RECT;
+        }
+        double xrect, yrect;
+        latlon2rect(n_proj, TEST_ORIG_LAT, TEST_ORIG_LON, &xrect, &yrect);
+        printf("X: %f\n", xrect);
+        printf("Y: %f\n", yrect);
+    }
+    printf("\n");
+
+    return (0);
+
+}
+

--- a/misc/lonlat_2_xy.c
+++ b/misc/lonlat_2_xy.c
@@ -80,12 +80,15 @@ int main(int argc, char *argv[]) {
 #define MAP_ORIG_LAT 0.0
 #define MAP_ORIG_LON 9.0
 #define ROTATION_ANGLE 0.0
+#define FALSE_EASTING 500000
+#define SCALE_FACTOR 0.9996
 
     int num_projections = 1;
     char trans[num_projections][999];
 
     int n = 0;
-    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f ", EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE);
+    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f %d %f ",
+            EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE, FALSE_EASTING, SCALE_FACTOR);
 
     for (int n_proj = 0; n_proj < num_projections; n_proj++) {
         get_transform(n_proj, trans[n_proj]);
@@ -107,8 +110,12 @@ int main(int argc, char *argv[]) {
         }
         double xrect, yrect;
         latlon2rect(n_proj, TEST_ORIG_LAT, TEST_ORIG_LON, &xrect, &yrect);
-        printf("X: %f\n", xrect);
-        printf("Y: %f\n", yrect);
+        printf("X (in m): %.2f\n", xrect * 1000);
+        printf("Y (in m): %.2f\n", yrect * 1000);
+        double dlat, dlon;
+        rect2latlon(n_proj, xrect, yrect, &dlat, &dlon);
+        printf("delta lon (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LON - dlon);
+        printf("delta lat (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LAT - dlat);
     }
     printf("\n");
 

--- a/misc/lonlat_2_xy.c
+++ b/misc/lonlat_2_xy.c
@@ -74,24 +74,23 @@ int main(int argc, char *argv[]) {
     SetConstants();
 
 // emulate https://epsg.io/25832
-#define EARTH_ELLIPSOID "GRS-80"
-#define MAP_ORIG_LAT 0.0
-#define MAP_ORIG_LON 9.0
-#define ROTATION_ANGLE 0.0
-#define USE_FALSE_EASTING 1
-#define FALSE_EASTING 500000
-#define SCALE_FACTOR 0.9996
+// TRANS_MERC GRS-80 0.0 9.0 0.0 1 500000 0.9996
+//#define EARTH_ELLIPSOID "GRS-80"
+//#define MAP_ORIG_LAT 0.0
+//#define MAP_ORIG_LON 9.0
+//#define ROTATION_ANGLE 0.0
+//#define USE_FALSE_EASTING 1
+//#define FALSE_EASTING 500000
+//#define SCALE_FACTOR 0.9996
 
-    int num_projections = 1;
-    char trans[num_projections][999];
+    char trans[999];
 
-    int n = 0;
-    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f %d %d %f ",
-            EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE, USE_FALSE_EASTING, FALSE_EASTING, SCALE_FACTOR);
+    printf("Enter transformation string (the part after 'TRANS '): ");
+    scanf("%[^\n]", &trans);
+    //sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f %d %d %f ",
+    //        EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE, USE_FALSE_EASTING, FALSE_EASTING, SCALE_FACTOR);
 
-    for (int n_proj = 0; n_proj < num_projections; n_proj++) {
-        get_transform(n_proj, trans[n_proj]);
-    }
+    get_transform(0, trans);
 
     float TEST_ORIG_LAT;
     float TEST_ORIG_LON;
@@ -101,21 +100,19 @@ int main(int argc, char *argv[]) {
     printf("Longitude: %f\n", TEST_ORIG_LON);
     printf("Latitude: %f\n", TEST_ORIG_LAT);
 
-    for (int n_proj = 0; n_proj < num_projections; n_proj++) {
-        if (strcmp(map_trans_type[n_proj], "GLOBAL") == 0) {
-            GeometryMode = MODE_GLOBAL;
-        } else {
-            GeometryMode = MODE_RECT;
-        }
-        double xrect, yrect;
-        latlon2rect(n_proj, TEST_ORIG_LAT, TEST_ORIG_LON, &xrect, &yrect);
-        printf("X (in m): %.2f\n", xrect * 1000);
-        printf("Y (in m): %.2f\n", yrect * 1000);
-        double dlat, dlon;
-        rect2latlon(n_proj, xrect, yrect, &dlat, &dlon);
-        printf("delta lon (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LON - dlon);
-        printf("delta lat (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LAT - dlat);
+    if (strcmp(map_trans_type[0], "GLOBAL") == 0) {
+        GeometryMode = MODE_GLOBAL;
+    } else {
+        GeometryMode = MODE_RECT;
     }
+    double xrect, yrect;
+    latlon2rect(0, TEST_ORIG_LAT, TEST_ORIG_LON, &xrect, &yrect);
+    printf("X (in m): %.2f\n", xrect * 1000);
+    printf("Y (in m): %.2f\n", yrect * 1000);
+    double dlat, dlon;
+    rect2latlon(0, xrect, yrect, &dlat, &dlon);
+    printf("delta lon (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LON - dlon);
+    printf("delta lat (lon/lat -> X/Y -> lon/lat): %g\n", TEST_ORIG_LAT - dlat);
     printf("\n");
 
     return (0);

--- a/misc/lonlat_2_xy.c
+++ b/misc/lonlat_2_xy.c
@@ -74,12 +74,11 @@ int main(int argc, char *argv[]) {
     SetConstants();
 
 // emulate https://epsg.io/25832
-// false easting should be 500000 for correct results, but hard coded to 0 right now
-// scale factor should be 0.9996 for correct results, but is hard coded to 1.0 right now
 #define EARTH_ELLIPSOID "GRS-80"
 #define MAP_ORIG_LAT 0.0
 #define MAP_ORIG_LON 9.0
 #define ROTATION_ANGLE 0.0
+#define USE_FALSE_EASTING 1
 #define FALSE_EASTING 500000
 #define SCALE_FACTOR 0.9996
 
@@ -87,8 +86,8 @@ int main(int argc, char *argv[]) {
     char trans[num_projections][999];
 
     int n = 0;
-    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f %d %f ",
-            EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE, FALSE_EASTING, SCALE_FACTOR);
+    sprintf(trans[n++], "TRANS_MERC %s %f  %f  %f %d %d %f ",
+            EARTH_ELLIPSOID, MAP_ORIG_LAT, MAP_ORIG_LON, ROTATION_ANGLE, USE_FALSE_EASTING, FALSE_EASTING, SCALE_FACTOR);
 
     for (int n_proj = 0; n_proj < num_projections; n_proj++) {
         get_transform(n_proj, trans[n_proj]);


### PR DESCRIPTION
This is some changes I had to make to get the utilities in `misc/` to compile when looking into #21.

I also added a tiny helper program to just convert one set of lon/lat with a given `TRANS` command line, similar to `compare_geog_trans` but much slimmer.

I only wasn't sure about b34ead44096d20e44e, but all instances where this function is used throughout the code base sets that last parameter to `0`, so I did too. Maybe you want to have a look.

I disabled compilation of GridXY2XYZ since it showed some errors I didnt immediately know what to do about, see c5300fea02fcf37e9f.