### PR TITLE
TRANS_MERC: make it possible to specify value of false easting and map scale factor

### DIFF
--- a/docs/programs/control.ControlFile.rst
+++ b/docs/programs/control.ControlFile.rst
@@ -100,7 +100,7 @@ Generic Control Statements
 | Syntax 3: ``TRANS`` ``NONE``
 | Syntax 4: ``TRANS`` ``SDC latOrig longOrig rotAngle``
 | Syntax 5: ``TRANS`` ``LAMBERT refEllipsoid latOrig longOrig firstStdParal secondStdParal rotAngle``
-| Syntax 6: ``TRANS`` ``TRANS_MERC refEllipsoid latOrig longOrig rotAngle``
+| Syntax 6: ``TRANS`` ``TRANS_MERC refEllipsoid latOrig longOrig rotAngle [useFalseEasting] [falseEasting mapScaleFactor]``
 | Syntax 7: ``TRANS`` ``AZIMUTHAL_EQUIDIST refEllipsoid latOrig longOrig rotAngle``
 | Sets geographic to working coordinates transformation parameters. The
  `GLOBAL`` option sets spherical regional/teleseismic mode, with no
@@ -129,6 +129,13 @@ Generic Control Statements
 |    ``rotAngle`` (*float*, min:\ ``-360.0``, max:\ ``360.0``) rotation
   angle of geographic north in degrees clockwise relative to the
   rectangular coordinates system Y-axis
+|    ``useFalseEasting`` (*choice*: `0 1``) whether to use
+  false easting in UTM coordinates or not
+|    ``falseEasting`` (*int*) false easting in meters to use in UTM coordinates,
+  defaults to ``500000`` (500km) if not specified and ``useFalseEasting`` is
+  switched on
+|    ``mapScaleFactor`` (*float*) map scale factor to use in UTM coordinate
+  conversion, defaults to ``1.0`` if not specified
 | Notes:
 |    1. `` rotAngle                ` = ``0`` gives
   North along the positive Y-axis,

--- a/docs/programs/control.ControlFile.rst
+++ b/docs/programs/control.ControlFile.rst
@@ -100,7 +100,7 @@ Generic Control Statements
 | Syntax 3: ``TRANS`` ``NONE``
 | Syntax 4: ``TRANS`` ``SDC latOrig longOrig rotAngle``
 | Syntax 5: ``TRANS`` ``LAMBERT refEllipsoid latOrig longOrig firstStdParal secondStdParal rotAngle``
-| Syntax 6: ``TRANS`` ``TRANS_MERC refEllipsoid latOrig longOrig rotAngle [useFalseEasting] [falseEasting mapScaleFactor]``
+| Syntax 6: ``TRANS`` ``TRANS_MERC refEllipsoid latOrig longOrig rotAngle [useFalseEasting] [falseEasting] [mapScaleFactor]``
 | Syntax 7: ``TRANS`` ``AZIMUTHAL_EQUIDIST refEllipsoid latOrig longOrig rotAngle``
 | Sets geographic to working coordinates transformation parameters. The
  `GLOBAL`` option sets spherical regional/teleseismic mode, with no

--- a/src/GridLib.c
+++ b/src/GridLib.c
@@ -683,8 +683,9 @@ int get_transform(int n_proj, char* in_line) {
 
         // 5: old, when omitting UseFalseEasting
         // 6: old, when specifying UseFalseEasting
+        // 7: new, when specifying UseFalseEasting, FalseEasting but not ScaleFactor
         // 8: new, when specifying UseFalseEasting, FalseEasting and ScaleFactor
-        if (ierr < 0 || (istat != 5 && istat != 6 && istat != 8)) {
+        if (ierr < 0 || (istat != 5 && istat != 6 && istat != 7 && istat != 8)) {
             nll_puterr("ERROR: reading TRANS_MERC transformation parameters");
             return (-1);
         }

--- a/src/include/GridLib.h
+++ b/src/include/GridLib.h
@@ -710,7 +710,8 @@ EXTERN_TXT int map_itype[NUM_PROJ_MAX]; /* int id of projection */
 EXTERN_TXT char MapProjStr[NUM_PROJ_MAX][2 * MAXLINE]; /* string description of proj params */
 EXTERN_TXT char map_ref_ellipsoid[NUM_PROJ_MAX][MAXLINE]; /* name of reference ellipsoid */
 /* general map parameters */
-EXTERN_TXT double map_orig_lat[NUM_PROJ_MAX], map_orig_long[NUM_PROJ_MAX], map_rot[NUM_PROJ_MAX];
+EXTERN_TXT double map_orig_lat[NUM_PROJ_MAX], map_orig_long[NUM_PROJ_MAX], map_rot[NUM_PROJ_MAX], map_scale_factor[NUM_PROJ_MAX];
+EXTERN_TXT long map_false_easting[NUM_PROJ_MAX];
 EXTERN_TXT double map_cosang[NUM_PROJ_MAX], map_sinang[NUM_PROJ_MAX]; /* rotation */
 /* LAMBERT projection parameters */
 EXTERN_TXT double map_lambert_1st_std_paral[NUM_PROJ_MAX], map_lambert_2nd_std_paral[NUM_PROJ_MAX];

--- a/src/include/map_project.h
+++ b/src/include/map_project.h
@@ -7,14 +7,14 @@ int lamb(int n_proj, double lon, double lat, double *x, double *y);
 int ilamb(int n_proj, double *lon, double *lat, double x, double y);
 
 // Transverse Mercator Projection (TM)
-void vtm(int n_proj, double lon0, double lat0, int use_false_easting);
+void vtm(int n_proj, double lon0, double lat0, int use_false_easting, long false_easting, double map_scale_factor);
 void tm(int n_proj, double lon, double lat, double *x, double *y);
 void itm(int n_proj, double *lon, double *lat, double x, double y);
 
 // Universal Transverse Mercator Projection (UTM)
 void utm(int n_proj, double lon, double lat, double *x, double *y);
 void iutm(int n_proj, double *lon, double *lat, double x, double y);
-void vutm(int n_proj, double lon0, int lat0, int use_false_easting);
+void vutm(int n_proj, double lon0, int lat0, int use_false_easting, long false_easting, double map_scale_factor);
 
 /* Azimuthal Equidistant Projection (AE) */
 void vazeqdist(int n_proj, double lon0, double lat0);


### PR DESCRIPTION
This enables users to have more control over UTM conversions, enabling to remodel many more real world coordinate systems. This way, one can avoid having to set up a custom coordinate system for NonLinloc, which means having to setup models and station coordinates in special and otherwise not useful coordinate systems and instead use well known UTM coordinate reference systems for the area at hand like the regionally officially used CRS by e.g. local geodetic/geologic services.

This should be fully backwards compatible.

I tried this new implementation with the new helper script from #23 with the coordinate system used by Bavarian state services and compared some lat/lon points against x/y values calculated using trusted `proj` command line tools. Results agree down to about 0-15 centimeters with some values I tested.

https://epsg.io/25832

`TRANS_MERC GRS-80 0.0 9.0 0.0 1 500000 0.9996`

```
$ ./lonlat_2_xy 
Enter transformation string (the part after 'TRANS '): TRANS_MERC GRS-80 0.0 9.0 0.0 1 500000 0.9996
Enter longitude and latitude, separated by space: 12.1234 48.1234
Longitude: 12.123400
Latitude: 48.123402
X (in m): 732422.97
Y (in m): 5334735.18
delta lon (lon/lat -> X/Y -> lon/lat): -6.77232e-09
delta lat (lon/lat -> X/Y -> lon/lat): -1.90045e-09

$ echo 12.1234 48.1234 | proj +proj=tmerc +lat_0=0 +lon_0=9 +k_0=0.9996 +x_0=500000 +y_0=0 +ellps=GRS80 +units=m
732422.99   5334735.01

$ echo 12.1234 48.1234 | cs2cs +init=epsg:4326 +to +init=epsg:25832 -f %.2f
732422.99   5334735.01 0.00

$ ./lonlat_2_xy 
Enter transformation string (the part after 'TRANS '): TRANS_MERC GRS-80 0.0 9.0 0.0 
Enter longitude and latitude, separated by space: 12.1234 48.1234
Longitude: 12.123400
Latitude: 48.123402
X (in m): 232515.97
Y (in m): 5336869.92
delta lon (lon/lat -> X/Y -> lon/lat): -6.77233e-09
delta lat (lon/lat -> X/Y -> lon/lat): -1.90045e-09

$ echo 12.1234 48.1234 | proj +proj=tmerc +lat_0=0 +lon_0=9 +ellps=GRS80 +units=m
232516.00   5336869.76
```

closes #22 

Let me know what you think @alomax and I can make further adjustments if needed. Not a C guru, so if anything is done poorly just let me know.