### PR TITLE
Bug in TransverseMercator: use of uninitialized variable

### DIFF
--- a/src/map_project.c
+++ b/src/map_project.c
@@ -404,6 +404,7 @@ void vtm(int n_proj, double lon0, double lat0, int use_false_easting, long false
     double lon, lat, x, y;
     lon = lon0;
     lat = lat0;
+    TransverseMercator[n_proj].y_central_parralel = 0;
     tm(n_proj, lon, lat, &x, &y);
     TransverseMercator[n_proj].y_central_parralel = y;
 }


### PR DESCRIPTION
The function `tm` is used to compute the `y_central_parralel` valule. However the `y_central_parralel` is used within `tm`.