### PR TITLE
Correct cmake list typo

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,10 +122,10 @@ target_link_libraries(Vel2Grid velmod GRID_LIB_OBJS m)
 # --------------------------------------------------------------------------
 # Grid2Time
 #
-add_library(Time_3d_NLL_multisource OBJECT Time_3d_NLL_multisource.c)
+add_library(Time_3d_NLL_multiSource OBJECT Time_3d_NLL_multiSource.c)
 target_compile_options(Time_3d_NLL_multisource PRIVATE "-DNO_IEEE_PROTOCOL")
 add_executable(Grid2Time Grid2Time1.c)
-target_link_libraries(Grid2Time Time_3d_NLL_multisource GRID_LIB_OBJS m)
+target_link_libraries(Grid2Time Time_3d_NLL_multiSource GRID_LIB_OBJS m)
 
 # --------------------------------------------------------------------------
 # Time2Angles

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ target_link_libraries(Vel2Grid velmod GRID_LIB_OBJS m)
 # Grid2Time
 #
 add_library(Time_3d_NLL_multiSource OBJECT Time_3d_NLL_multiSource.c)
-target_compile_options(Time_3d_NLL_multisource PRIVATE "-DNO_IEEE_PROTOCOL")
+target_compile_options(Time_3d_NLL_multiSource PRIVATE "-DNO_IEEE_PROTOCOL")
 add_executable(Grid2Time Grid2Time1.c)
 target_link_libraries(Grid2Time Time_3d_NLL_multiSource GRID_LIB_OBJS m)
 


### PR DESCRIPTION
Running Cmake results in an error when adding the Time_3d_NLL_multisource due to a mismatch in capitalisation. This just changes the capitalisation in the cmakelist file to match the file name - not sure if that is actually the way you want it to be.

The main reason for running into this is I have a docker container that clones this repo and builds from it for a real-time aftershock pipeline. 